### PR TITLE
Mirror of mapbox mapbox-android-demo#1187

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MatrixApiActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MatrixApiActivity.java
@@ -90,7 +90,6 @@ public class MatrixApiActivity extends AppCompatActivity implements MapboxMap.On
       @Override
       public void onMapReady(@NonNull final MapboxMap mapboxMap) {
         MatrixApiActivity.this.mapboxMap = mapboxMap;
-
         mapboxMap.setStyle(new Style.Builder().fromUri("mapbox://styles/mapbox/cj8gg22et19ot2rnz65958fkn")
             // Add the SymbolLayer icon image to the map style
             .withImage(ICON_ID, BitmapFactory.decodeResource(
@@ -131,13 +130,15 @@ public class MatrixApiActivity extends AppCompatActivity implements MapboxMap.On
     List<Feature> renderedStationFeatures = mapboxMap.queryRenderedFeatures(
       mapboxMap.getProjection().toScreenLocation(point), LAYER_ID);
     if (!renderedStationFeatures.isEmpty()) {
-      Point pointOfSelectedStation = (Point) renderedStationFeatures.get(0).geometry();
-      if (pointOfSelectedStation != null) {
-        String selectedBoltFeatureName = renderedStationFeatures.get(0).getStringProperty(STATION_NAME_PROPERTY);
+      Feature featureOfSelectedStation = renderedStationFeatures.get(0);
+      if (featureOfSelectedStation != null) {
+        String selectedBoltFeatureName = featureOfSelectedStation.getStringProperty(STATION_NAME_PROPERTY);
         List<Feature> featureList = featureCollection.features();
-        for (int i = 0; i < featureList.size(); i++) {
-          if (featureList.get(i).getStringProperty(STATION_NAME_PROPERTY).equals(selectedBoltFeatureName)) {
-            makeMapboxMatrixApiCall(i);
+        if (featureList != null) {
+          for (int i = 0; i < featureList.size(); i++) {
+            if (featureList.get(i).getStringProperty(STATION_NAME_PROPERTY).equals(selectedBoltFeatureName)) {
+              makeMapboxMatrixApiCall(i);
+            }
           }
         }
       }
@@ -222,20 +223,6 @@ public class MatrixApiActivity extends AppCompatActivity implements MapboxMap.On
         Timber.d("onResponse onFailure");
       }
     });
-  }
-
-  private void addMarkers() {
-    Icon lightningBoltIcon = IconFactory.getInstance(MatrixApiActivity.this)
-      .fromResource(R.drawable.lightning_bolt);
-    if (featureCollection.features() != null) {
-      for (Feature feature : featureCollection.features()) {
-        mapboxMap.addMarker(new MarkerOptions()
-          .position(new LatLng(feature.getProperty("Latitude").getAsDouble(),
-            feature.getProperty("Longitude").getAsDouble()))
-          .snippet(feature.getStringProperty("Station_Name"))
-          .icon(lightningBoltIcon));
-      }
-    }
   }
 
   private String loadGeoJsonFromAsset(String filename) {

--- a/MapboxAndroidDemo/src/main/res/layout/activity_matrix_api.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_matrix_api.xml
@@ -11,6 +11,7 @@
         mapbox:mapbox_cameraTargetLat="42.3600825"
         mapbox:mapbox_cameraTargetLng="-71.0588801"
         mapbox:mapbox_cameraZoom="11.193"
+        mapbox:mapbox_uiCompassMarginTop="79dp"
         />
 
     <androidx.recyclerview.widget.RecyclerView

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -209,7 +209,7 @@
     <!-- Matrix API -->
     <string name="call_error">Oh no! The call to the Directions Matrix API failed</string>
     <string name="miles_distance">%1$s miles</string>
-    <string name="click_on_marker_instruction_toast">Click on a bolt marker to get started</string>
+    <string name="click_on_marker_instruction_toast">Click on a bolt icon to get started</string>
 
     <!-- Geocoding -->
     <string name="latitude">latitude</string>


### PR DESCRIPTION
Mirror of mapbox mapbox-android-demo#1187
`MatrixApiActivity` was using a bunch of deprecated Maps SDK classes and methods, such as `addMarker()`, `setOnMarkerClickListener()`, etc.

This pr brings this example up-to-date with `SymbolLayer` icons, `onMapClick()` logic, adding null checks, etc.  This pr gets rid of the final usage of `addMarker()` 🐛 🔨 
